### PR TITLE
Version 1.12.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   script: python -m pip install --no-deps --ignore-installed . --no-build-isolation
   number: 0
+  skip: True  # [s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,14 +18,18 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python
     - setuptools
     - wheel
 
   run:
-    - python >=3.5
+    - python
     - requests >=2.22.0
-    - authlib
+    - cryptography
+    - zeep
+    - pyjwt
+    - more-itertools
+    - pendulum
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,8 @@ source:
 
 build:
   noarch: python
-  script: python -m pip install --no-deps --ignore-installed .
-  number: 1
+  script: python -m pip install --no-deps --ignore-installed . --no-build-isolation
+  number: 0
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: '{{ environ['RECIPE_DIR'] }}/LICENSE.txt'
-
+  doc_url: https://simple-salesforce.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "simple-salesforce" %}
-{% set version = "1.11.2" %}
-{% set sha256sum = "995cf718bb240617b4c02c39c2c20288582916b11b06e7ebb6fb360729ee439b" %}
+{% set version = "1.12.5" %}
+{% set sha256sum = "ef65f72438e3b215619f6835d3d4356e147adf3a7ece6896d239127dd6aefcd1" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
   sha256: {{ sha256sum }}
 
 build:
-  noarch: python
   script: python -m pip install --no-deps --ignore-installed . --no-build-isolation
   number: 0
 


### PR DESCRIPTION
simple-salesforece 1.12.5

**Destination channel:** defaults

### Links

- [PKG-3417](https://anaconda.atlassian.net/browse/PKG-3417)
- [Upstream repository](https://github.com/simple-salesforce/simple-salesforce/tree/v1.12.5)
- [Upstream changelog/diff](https://github.com/simple-salesforce/simple-salesforce/blob/v1.12.5/CHANGES)

### Explanation of changes:

- Update version
- Dependency updates
- Linter fixes
- Skip `s390x` since `zeep` isn't available


[PKG-3417]: https://anaconda.atlassian.net/browse/PKG-3417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ